### PR TITLE
builds: adds poc for esbuild paths for sdk

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+export HANDLER="lib/index.ts"
+export BUILD_DIR="$(mktemp -d)"
+
+npx esbuild \
+  --log-level=error \
+  --bundle \
+  --outfile="$BUILD_DIR/index.js" \
+  --metafile="$BUILD_DIR/metafile.json" \
+  --tsconfig="tsconfig.json" \
+  --sourcemap=inline \
+  --sources-content=false \
+  --platform=node \
+  "$HANDLER"
+
+stat -f %z "$BUILD_DIR"/index.js
+
+npx esbuild \
+  --log-level=error \
+  --bundle \
+  --outfile="$BUILD_DIR/index.js" \
+  --metafile="$BUILD_DIR/metafile.json" \
+  --tsconfig="tsconfig.paths.json" \
+  --sourcemap=inline \
+  --sources-content=false \
+  --platform=node \
+  "$HANDLER"
+
+stat -f %z "$BUILD_DIR"/index.js

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "paths": {
+      "@aws-sdk/*": [
+        "./node_modules/@aws-sdk/*/dist-es",
+        "./node_modules/@aws-sdk/*"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
For #1 

```
❯ bin/build.sh
2570064
398644
```

Just need to translate all of the options to the CDK esbuild props.